### PR TITLE
Remove escaped chars from title

### DIFF
--- a/Configuration/TypoScript/Setup/Setup.typoscript
+++ b/Configuration/TypoScript/Setup/Setup.typoscript
@@ -169,7 +169,8 @@ config {
     no_cache = {$config.no_cache}
     uniqueLinkVars = 1
     pageTitleFirst = 0
-    pageTitleSeparator = &nbsp;&middot;&nbsp;
+    pageTitleSeparator = ·
+    pageTitleSeparator.noTrimWrap = | | |
     prefixLocalAnchors = {$config.prefixLocalAnchors}
     renderCharset = utf-8
     metaCharset = utf-8


### PR DESCRIPTION
In TYPO3 9.5.4 the old config produces this output `My Website&amp;nbsp;&amp;middot;&amp;nbsp; Home`, which is wrong because the new Title Tag API escapes everything on its own. 
The change would fix that. Not tested on a previous version of TYPO3.